### PR TITLE
Updates plugin execution

### DIFF
--- a/context_datalayer.install
+++ b/context_datalayer.install
@@ -1,0 +1,27 @@
+<?php
+/**
+ * @file
+ * Context Datalayer installation file.
+ */
+
+/**
+ * Implements hook_install().
+ */
+function context_datalayer_install() {
+  // Make the module heavy so it runs after other modules utilise
+  // hook_datalayer_alter().
+  db_update('system')
+    ->fields(array('weight' => 1000))
+    ->condition('name', 'context_datalayer')
+    ->execute();
+}
+
+/**
+ * Make the module heavier to benefit hook_datalayer_alter().
+ */
+function context_datalayer_update_7000() {
+  db_update('system')
+    ->fields(array('weight' => 1000))
+    ->condition('name', 'context_datalayer')
+    ->execute();
+}

--- a/context_datalayer.module
+++ b/context_datalayer.module
@@ -25,20 +25,14 @@ function context_datalayer_theme() {
 }
 
 /**
- * Implements hook_context_page_condition().
+ * Implements hook_datalayer_alter().
  */
-function context_datalayer_context_page_condition() {
+function context_datalayer_datalayer_alter(&$datalayer) {
   if ($plugin = context_get_plugin('condition', 'context_datalayer_condition')) {
-    $plugin->execute();
+    $plugin->execute($datalayer);
   }
-}
-
-/**
- * Implements hook_context_page_reaction().
- */
-function context_datalayer_context_page_reaction() {
   if ($plugin = context_get_plugin('reaction', 'context_datalayer_reaction')) {
-    $plugin->execute();
+    $plugin->execute($datalayer);
   }
 }
 

--- a/plugins/context_datalayer_condition.inc
+++ b/plugins/context_datalayer_condition.inc
@@ -145,9 +145,8 @@ class context_datalayer_condition extends context_condition {
   /**
    * Execute.
    */
-  public function execute() {
+  public function execute($datalayer) {
     if ($this->condition_used()) {
-      $datalayer = datalayer_add();
       foreach ($this->get_contexts() as $context) {
         foreach ($this->fetch_from_context($context, 'values') as $key => $value) {
           if (isset($datalayer[$key]) && $datalayer[$key] = $value) {

--- a/plugins/context_datalayer_reaction.inc
+++ b/plugins/context_datalayer_reaction.inc
@@ -158,11 +158,16 @@ class context_datalayer_reaction extends context_reaction {
   /**
    * Execute.
    */
-  public function execute() {
+  public function execute(&$datalayer) {
     foreach ($this->get_contexts() as $context) {
       $options = $this->fetch_from_context($context);
       if (!empty($options['data'])) {
-        datalayer_add($options['data'], $options['overwrite']);
+        if ($options['overwrite']) {
+          $datalayer = array_merge($datalayer, $options['data']);
+        }
+        else {
+          $datalayer += $options['data'];
+        }
       }
     }
   }


### PR DESCRIPTION
Allow conditions and reactions to fire in the only place they can actually make a difference...

Annoyingly you can't actually use `datalayer_add()` to manipulate the datalayer as the part of the module which adds entity information to the datalayer doesn't actually add anything to the static array...  It simply builds another array for output, hence I had to duplicate the "overwrite" functionality in the reaction execute method...
