### PR TITLE
Issue #2936904: UI elements for casting values to specified type

### DIFF
--- a/src/Plugin/ContextReaction/DataLayer.php
+++ b/src/Plugin/ContextReaction/DataLayer.php
@@ -39,7 +39,17 @@ class DataLayer extends ContextReactionPluginBase {
     $config = $this->getConfiguration();
     $data = [];
     foreach ($config['data'] as $item) {
-      $data[$item['key']] = $item['value'];
+      switch ($item['type']) {
+        case 'integer':
+          $value = (int) $item['value'];
+          break;
+        case 'boolean':
+          $value = (bool) $item['value'];
+          break;
+        default:
+          $value = $item['value'];
+      }
+      $data[$item['key']] = $value;
     }
     return [
       'data' => $data,

--- a/tests/src/Functional/DataLayerContextReactionFunctionalTest.php
+++ b/tests/src/Functional/DataLayerContextReactionFunctionalTest.php
@@ -156,6 +156,41 @@ class DataLayerContextReactionFunctionalTest extends BrowserTestBase {
     $assert->pageTextContains('No key/value pairs found');
     $assert->pageTextNotContains('"baz":"qux"');
     $assert->pageTextNotContains('"quux":"qub"');
+    // Verify type output.
+    $this->drupalPostForm(
+      'admin/structure/context/datalayer_test_context',
+      [
+        'reactions[datalayer][new][key]' => 'foo',
+        'reactions[datalayer][new][value]' => 'bar',
+        'reactions[datalayer][new][type]' => 'string',
+        'reactions[datalayer][add_new_pair]' => '1',
+      ],
+      t('Add new pair')
+    );
+    $this->drupalPostForm(
+      'admin/structure/context/datalayer_test_context',
+      [
+        'reactions[datalayer][new][key]' => 'bar',
+        'reactions[datalayer][new][value]' => '2018',
+        'reactions[datalayer][new][type]' => 'integer',
+        'reactions[datalayer][add_new_pair]' => '1',
+      ],
+      t('Add new pair')
+    );
+    $this->drupalPostForm(
+      'admin/structure/context/datalayer_test_context',
+      [
+        'reactions[datalayer][new][key]' => 'baz',
+        'reactions[datalayer][new][value]' => '1',
+        'reactions[datalayer][new][type]' => 'boolean',
+        'reactions[datalayer][add_new_pair]' => '1',
+      ],
+      t('Add new pair')
+    );
+    $this->drupalGet('admin/structure/context/datalayer_test_context');
+    $assert->pageTextContains('"foo":"bar"');
+    $assert->pageTextContains('"bar":2018');
+    $assert->pageTextContains('"baz":true');
   }
 
 }

--- a/tests/src/Kernel/DataLayerContextReactionKernelTest.php
+++ b/tests/src/Kernel/DataLayerContextReactionKernelTest.php
@@ -40,6 +40,26 @@ class DataLayerContextReactionKernelTest extends EntityKernelTestBase {
           'value' => 'barbaz',
           'type' => 'bazqux',
         ],
+        [
+          'key' => 'foostring',
+          'value' => 'barbaz',
+          'type' => 'string',
+        ],
+        [
+          'key' => 'foointeger',
+          'value' => '2042',
+          'type' => 'integer',
+        ],
+        [
+          'key' => 'foobooleantrue',
+          'value' => '1',
+          'type' => 'boolean',
+        ],
+        [
+          'key' => 'foobooleanfalse',
+          'value' => '0',
+          'type' => 'boolean',
+        ],
       ],
     ];
     // Define expected data to be sent to datalayer_add().
@@ -47,13 +67,17 @@ class DataLayerContextReactionKernelTest extends EntityKernelTestBase {
       'data' => [
         'foo' => 'bar',
         'foobar' => 'barbaz',
+        'foostring' => 'barbaz',
+        'foointeger' => 2042,
+        'foobooleantrue' => TRUE,
+        'foobooleanfalse' => FALSE,
       ],
       'overwrite' => 0,
     ];
     // Create a mock of our plugin so that we can use mock facilities.
     $plugin = new DataLayer($configuration, 'datalayer', '');
     // Invoke execute().
-    $this->assertEquals($expected, $plugin->execute());
+    $this->assertSame($expected, $plugin->execute());
   }
 
 }


### PR DESCRIPTION
Drupal.org Issue: https://www.drupal.org/project/context_datalayer/issues/2936904

This PR improves the datalayer context reaction to output key/value pairs using the specified data type.