### PR TITLE
Issue #2937374: Overwrite option should merge datalayer arrays

### DIFF
--- a/context_datalayer.module
+++ b/context_datalayer.module
@@ -11,12 +11,13 @@
 function context_datalayer_datalayer_alter(&$datalayer) {
   /** @var \Drupal\context\ContextManager $context_manager */
   $context_manager = \Drupal::service('context.manager');
-
   foreach ($context_manager->getActiveReactions('datalayer') as $reaction) {
     $config = $reaction->execute();
-    $datalayer += $config['data'];
     if ($config['overwrite']) {
-      $datalayer = $config['data'];
+      $datalayer = array_merge($datalayer, $config['data']);
+    }
+    else {
+      $datalayer += $config['data'];
     }
   }
 }

--- a/src/Plugin/ContextReaction/DataLayer.php
+++ b/src/Plugin/ContextReaction/DataLayer.php
@@ -43,9 +43,11 @@ class DataLayer extends ContextReactionPluginBase {
         case 'integer':
           $value = (int) $item['value'];
           break;
+
         case 'boolean':
           $value = (bool) $item['value'];
           break;
+
         default:
           $value = $item['value'];
       }

--- a/tests/src/Functional/DataLayerContextReactionFunctionalTest.php
+++ b/tests/src/Functional/DataLayerContextReactionFunctionalTest.php
@@ -82,19 +82,6 @@ class DataLayerContextReactionFunctionalTest extends BrowserTestBase {
     $assert->pageTextNotContains('No key/value pairs found');
     $assert->pageTextContains('"foo":"bar"');
     $assert->pageTextContains('"bar":"baz"');
-    // Verify datalayer overwrite.
-    $assert->pageTextContains('"drupalLanguage":"en"');
-    $this->drupalPostForm(
-      'admin/structure/context/datalayer_test_context',
-      [
-        'reactions[datalayer][datalayer_overwrite]' => '1',
-      ],
-      t('Save and continue')
-    );
-    $this->drupalGet('admin/structure/context/datalayer_test_context');
-    $assert->pageTextContains('"foo":"bar"');
-    $assert->pageTextContains('"bar":"baz"');
-    $assert->pageTextNotContains('"drupalLanguage":"en"');
     // Verify we can remove a pair.
     $this->drupalPostForm(
       'admin/structure/context/datalayer_test_context',
@@ -191,6 +178,22 @@ class DataLayerContextReactionFunctionalTest extends BrowserTestBase {
     $assert->pageTextContains('"foo":"bar"');
     $assert->pageTextContains('"bar":2018');
     $assert->pageTextContains('"baz":true');
+    // Verify datalayer overwrite.
+    $assert->pageTextContains('"drupalLanguage":"en"');
+    $this->drupalPostForm(
+      'admin/structure/context/datalayer_test_context',
+      [
+        'reactions[datalayer][new][key]' => 'drupalLanguage',
+        'reactions[datalayer][new][value]' => 'foobarbaz',
+        'reactions[datalayer][new][type]' => 'string',
+        'reactions[datalayer][add_new_pair]' => '1',
+        'reactions[datalayer][datalayer_overwrite]' => '1',
+      ],
+      t('Add new pair')
+    );
+    $this->drupalGet('admin/structure/context/datalayer_test_context');
+    $assert->pageTextNotContains('"drupalLanguage":"en"');
+    $assert->pageTextContains('"drupalLanguage":"foobarbaz"');
   }
 
 }


### PR DESCRIPTION
Drupal.org Issue: https://www.drupal.org/project/context_datalayer/issues/2937374

This PR modifies the overwrite configuration behavior to replicate the behavior of 7.x and/or `datalayer_add`.